### PR TITLE
Add user error type; run rustfmt

### DIFF
--- a/text/Cargo.toml
+++ b/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlvc-text"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -126,6 +126,7 @@ pub fn pack<'a>(pieces: impl IntoIterator<Item = &'a Piece>) -> Vec<u8> {
 pub fn dump<R>(mut src: tlvc::TlvcReader<R>) -> Vec<Piece>
 where
     R: tlvc::TlvcRead,
+    R::Error: core::fmt::Debug,
 {
     let mut pieces = vec![];
     loop {
@@ -168,6 +169,7 @@ where
 fn remaining_bytes<R>(src: tlvc::TlvcReader<R>, rewind: usize) -> Vec<u8>
 where
     R: tlvc::TlvcRead,
+    R::Error: core::fmt::Debug,
 {
     let (src, start, end) = src.into_inner();
     let start = start as usize - rewind;

--- a/tlvc/Cargo.toml
+++ b/tlvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlvc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tlvc/tests/basic.rs
+++ b/tlvc/tests/basic.rs
@@ -11,11 +11,13 @@ fn fixture(s: &str) -> Vec<u8> {
 }
 
 fn test_fixture_a() -> Vec<u8> {
-    fixture(r#"
+    fixture(
+        r#"
         [
             ("0x1d", [])
         ]
-    "#)
+    "#,
+    )
 }
 
 #[test]
@@ -28,6 +30,9 @@ fn read_header_a() {
     assert_eq!(h.len.get(), 0);
     assert_eq!(h.header_checksum.get(), h.compute_checksum());
 
-    assert_eq!(r.remaining(), (size_of::<ChunkHeader>() + size_of::<u32>()) as u64,
-    "read_header should not advance cursor");
+    assert_eq!(
+        r.remaining(),
+        (size_of::<ChunkHeader>() + size_of::<u32>()) as u64,
+        "read_header should not advance cursor"
+    );
 }

--- a/tool/Cargo.toml
+++ b/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlvctool"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This allows us to bubble up errors from user implementations of `TlvcRead`.