### PR TITLE
Derive Eq, PartialEq for TlvcReadError.

### DIFF
--- a/tlvc/Cargo.toml
+++ b/tlvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlvc"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tlvc/src/lib.rs
+++ b/tlvc/src/lib.rs
@@ -110,7 +110,7 @@ impl TlvcRead for std::sync::Arc<[u8]> {
 }
 
 /// Errors that can occur during the read process.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum TlvcReadError<E> {
     /// A header was found with the wrong checksum.
     HeaderCorrupt {


### PR DESCRIPTION
This helps Hubris applications use it in ringbufs, which require equality comparison.