### PR TITLE
Update `zerocopy` to 0.7

### DIFF
--- a/text/Cargo.toml
+++ b/text/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 serde = {version = "1", features = ["derive"]}
 ron = "0.8"
 tlvc = {path = "../tlvc"}
-zerocopy = "0.6"
+zerocopy = "0.7"

--- a/tlvc/Cargo.toml
+++ b/tlvc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 crc = "3.0"
-zerocopy = "0.6"
+zerocopy = { version = "0.7", features = ["derive"] }
 byteorder = {version = "1.4", default-features = false}
 
 [features]

--- a/tlvc/src/lib.rs
+++ b/tlvc/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(test), no_std)]
 
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// Shorthand type for little-endian `u32` used in the chunk header.
 pub type U32LE = zerocopy::U32<byteorder::LittleEndian>;
@@ -28,7 +28,14 @@ pub const fn header_checksum(tag: [u8; 4], len: u32) -> u32 {
 /// _don't_ require them to be aligned in local memory, so this uses the
 /// unaligned and explicitly little-endian version of `u32`.
 #[derive(
-    Copy, Clone, Debug, Default, AsBytes, FromBytes, zerocopy::Unaligned,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    AsBytes,
+    FromZeroes,
+    FromBytes,
+    zerocopy::Unaligned,
 )]
 #[repr(C)]
 pub struct ChunkHeader {


### PR DESCRIPTION
This likely warrants a minor version bump of the `tlvc` crate since dependents will also need to update their version of `zerocopy` if they're relying on the derive traits.